### PR TITLE
keeping pivotal ids in redis so we dont report more than once

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -6,5 +6,6 @@ task :email_delivered_stories => :environment do
   Rails.logger.info "Sending Email"
   reporter.email_report
   reporter.set_report_time
+  reporter.set_reported_stories
   Rails.logger.info "Done"
 end


### PR DESCRIPTION
We are querying for all stories in the delivered state that have not been updated since last deployment.  The problem is that often times stories are updated after they are delivered.  There does not look like a way to do this in pivotal from reading their search documentation so i just persisted the pivotal ids in redis.
